### PR TITLE
Fix .env loading path

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -11,7 +11,8 @@ from .utils.prompt import ClientMessage, convert_to_openai_messages
 from .utils.tools import get_current_weather
 
 
-load_dotenv(".env.local")
+# Load environment variables from .env for local development
+load_dotenv(".env")
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- load environment variables from `.env` instead of `.env.local`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510a4e7d888326b9b58481fa97fc82