### PR TITLE
Switch API to OpenRouter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-# Get your OpenAI API Key here: https://platform.openai.com/account/api-keys
-OPENAI_API_KEY=****
+# Get your OpenRouter API Key here: https://openrouter.ai
+OPENROUTER_API_KEY=****

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This template demonstrates the usage of [Data Stream Protocol](https://sdk.verce
 
 ## Deploy your own
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fai-sdk-preview-python-streaming&env=OPENAI_API_KEY&envDescription=API%20keys%20needed%20for%20application&envLink=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fai-sdk-preview-python-streaming%2Fblob%2Fmain%2F.env.example)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fai-sdk-preview-python-streaming&env=OPENROUTER_API_KEY&envDescription=API%20keys%20needed%20for%20application&envLink=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fai-sdk-preview-python-streaming%2Fblob%2Fmain%2F.env.example)
 
 ## How to use
 
@@ -24,7 +24,7 @@ pnpm create next-app --example https://github.com/vercel-labs/ai-sdk-preview-pyt
 
 To run the example locally you need to:
 
-1. Sign up for accounts with the AI providers you want to use (e.g., OpenAI, Anthropic).
+1. Sign up for accounts with the AI providers you want to use (e.g., OpenRouter, Anthropic).
 2. Obtain API keys for each provider.
 3. Set the required environment variables as shown in the `.env.example` file, but in a new file called `.env`.
 4. `pnpm install` to install the required Node dependencies.

--- a/api/index.py
+++ b/api/index.py
@@ -16,7 +16,8 @@ load_dotenv(".env.local")
 app = FastAPI()
 
 client = OpenAI(
-    api_key=os.environ.get("OPENAI_API_KEY"),
+    api_key=os.environ.get("OPENROUTER_API_KEY"),
+    base_url="https://openrouter.ai/api/v1",
 )
 
 

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -13,7 +13,7 @@ export const Navbar = () => {
         </Button>
       </Link>
 
-      <Link href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fai-sdk-preview-python-streaming&env=OPENAI_API_KEY%2CVERCEL_FORCE_PYTHON_STREAMING&envDescription=API+keys+needed+for+application&envLink=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fai-sdk-preview-python-streaming%2Fblob%2Fmain%2F.env.example&teamSlug=vercel-labs">
+      <Link href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fai-sdk-preview-python-streaming&env=OPENROUTER_API_KEY%2CVERCEL_FORCE_PYTHON_STREAMING&envDescription=API+keys+needed+for+application&envLink=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fai-sdk-preview-python-streaming%2Fblob%2Fmain%2F.env.example&teamSlug=vercel-labs">
         <Button>
           <VercelIcon />
           Deploy with Vercel


### PR DESCRIPTION
## Summary
- switch to OpenRouter in the FastAPI backend
- update sample environment variable
- update deploy links and docs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510b0c0cf88326ba02a50805b82139